### PR TITLE
Adding support for mounted folders

### DIFF
--- a/HidHideClient/src/HidHideApi.h
+++ b/HidHideClient/src/HidHideApi.h
@@ -34,7 +34,8 @@ namespace HidHide
     // Create a hierarchical tree of human interface devices starting at the base container id level
     DescriptionToHidDeviceInstancePathsWithModelInfo GetDescriptionToHidDeviceInstancePathsWithModelInfo();
 
-    // Method converting a logical file name into a full image name
+    // Determine the full image name for storage of the file specified while considering mounted folder structures
+    // Return an empty path when the specified file name can't be stored on any of the volumes present
     FullImageName FileNameToFullImageName(_In_ std::filesystem::path const& logicalFileName);
 
     // Get the control device state; returns true when the control device is present (installed and enabled)


### PR DESCRIPTION
When an application on the white list was stored in a mounted folder (NTFS), the client application picked the volume with the mount point while the driver received notifications that the application resided on the mounted volume. This change set ensures that both client and driver refer to the same (mounted) volume.