### PR TITLE
Avoid usage of message queue

### DIFF
--- a/HidHide/src/Device.c
+++ b/HidHide/src/Device.c
@@ -16,8 +16,6 @@ NTSTATUS HidHideCreateDevice(PWDFDEVICE_INIT wdfDeviceInit)
     WDF_OBJECT_ATTRIBUTES wdfObjectAttributes;
     WDF_FILEOBJECT_CONFIG wdfFileObjectConfig;
     WDFDEVICE             wdfDevice;
-    WDF_IO_QUEUE_CONFIG   wdfIoQueueConfig;
-    WDFQUEUE              wdfQueue;
     NTSTATUS              ntstatus;
 
     // This is a filter
@@ -38,29 +36,9 @@ NTSTATUS HidHideCreateDevice(PWDFDEVICE_INIT wdfDeviceInit)
     ntstatus = WdfDeviceCreateDeviceInterface(wdfDevice, &HidHideInterfaceGuid, NULL);
     if (!NT_SUCCESS(ntstatus)) LOG_AND_RETURN_NTSTATUS(L"WdfDeviceCreateDeviceInterface", ntstatus);
 
-    // Create the I/O requests queue
-    WDF_IO_QUEUE_CONFIG_INIT_DEFAULT_QUEUE(&wdfIoQueueConfig, WdfIoQueueDispatchParallel);
-    wdfIoQueueConfig.EvtIoDefault = HidHideDeviceEvtIoDefault;
-    ntstatus = WdfIoQueueCreate(wdfDevice, &wdfIoQueueConfig, WDF_NO_OBJECT_ATTRIBUTES, &wdfQueue);
-    if (!NT_SUCCESS(ntstatus)) LOG_AND_RETURN_NTSTATUS(L"WdfIoQueueCreate", ntstatus);
-
     // Initilize the device context for future usage
     ntstatus = OnDeviceCreate(wdfDevice);
     if (!NT_SUCCESS(ntstatus)) return (ntstatus);
 
     return (STATUS_SUCCESS);
-}
-
-_Use_decl_annotations_
-VOID HidHideDeviceEvtIoDefault(WDFQUEUE wdfQueue, WDFREQUEST wdfRequest)
-{
-    TRACE_PERFORMANCE(L"");
-
-    NTSTATUS ntstatus;
-
-    ntstatus = OnDeviceIoDefault(WdfIoQueueGetDevice(wdfQueue), wdfQueue, wdfRequest);
-    if (!NT_SUCCESS(ntstatus))
-    {
-        WdfRequestComplete(wdfRequest, ntstatus);
-    }
 }

--- a/HidHide/src/Device.h
+++ b/HidHide/src/Device.h
@@ -10,7 +10,4 @@ _IRQL_requires_same_
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS HidHideCreateDevice(_Inout_ PWDFDEVICE_INIT DeviceInit);
 
-// Notification handler called with every I/O request from the queue, unless request - specific callback functions have also been registered
-EVT_WDF_IO_QUEUE_IO_DEFAULT HidHideDeviceEvtIoDefault;
-
 EXTERN_C_END

--- a/HidHide/src/Logic.c
+++ b/HidHide/src/Logic.c
@@ -239,23 +239,6 @@ VOID OnDeviceFileCleanup(WDFFILEOBJECT wdfFileObject)
 }
 
 _Use_decl_annotations_
-NTSTATUS OnDeviceIoDefault(WDFDEVICE wdfDevice, WDFQUEUE wdfQueue, WDFREQUEST wdfRequest)
-{
-    TRACE_PERFORMANCE(L"");
-    UNREFERENCED_PARAMETER(wdfQueue);
-
-    WDF_REQUEST_SEND_OPTIONS wdfRequestSendOptions;
-
-    // Core functionality of an upper filter driver is to forward events to the next device on the device stack
-    // As we only act on the file create we shouldn't interfere with any other I/O requests
-    WdfRequestFormatRequestUsingCurrentType(wdfRequest);
-    WDF_REQUEST_SEND_OPTIONS_INIT(&wdfRequestSendOptions, WDF_REQUEST_SEND_OPTION_SEND_AND_FORGET);
-    if (FALSE == WdfRequestSend(wdfRequest, WdfDeviceGetIoTarget(wdfDevice), &wdfRequestSendOptions)) return (WdfRequestGetStatus(wdfRequest));
-
-    return (STATUS_SUCCESS);
-}
-
-_Use_decl_annotations_
 NTSTATUS OnControlDeviceCreate(WDFDEVICE wdfControlDevice)
 {
     TRACE_ALWAYS(L"");

--- a/HidHide/src/Logic.h
+++ b/HidHide/src/Logic.h
@@ -95,11 +95,6 @@ _IRQL_requires_same_
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS OnDeviceCreate(_In_ WDFDEVICE wdfDevice);
 
-// Hook called when a device I/O request is incoming
-_IRQL_requires_same_
-_IRQL_requires_max_(DISPATCH_LEVEL)
-NTSTATUS OnDeviceIoDefault(_In_ WDFDEVICE wdfDevice, _In_ WDFQUEUE wdfQueue, _In_ WDFREQUEST wdfRequest);
-
 // Hook called after having the control device created
 _IRQL_requires_same_
 _IRQL_requires_max_(PASSIVE_LEVEL)


### PR DESCRIPTION
The O/S should bypass the filter driver when a certain I/O message type isn't handled. The ds4windows community reports low frame rate responses when HidHide is used in the device stack. This version is an attempt to address this issue.