### PR TITLE
Fix invalid JSON format

### DIFF
--- a/HidHideCLI/src/Commands.cpp
+++ b/HidHideCLI/src/Commands.cpp
@@ -51,7 +51,7 @@ namespace
         for (auto const& hidContainer : hidDevices)
         {
             if (first) first = false; else os << L"," << std::endl;
-            os << L"{ \"friendlyName\" : " << hidContainer.first << L"\" , \"devices\" :" << hidContainer.second << L"} ";
+            os << L"{ \"friendlyName\" : \"" << hidContainer.first << L"\" , \"devices\" :" << hidContainer.second << L"} ";
         }
         os << L"] " << std::endl;
         return (os);

--- a/HidHideCLI/src/Commands.cpp
+++ b/HidHideCLI/src/Commands.cpp
@@ -7,24 +7,50 @@
 #include "Utils.h"
 #include "Volume.h"
 #include "Logging.h"
+#include <sstream>
+#include <iomanip>
 
 namespace
 {
+    // https://stackoverflow.com/a/33799784
+    std::string escape_json(const std::string &s) {
+        std::ostringstream o;
+        for (auto c = s.cbegin(); c != s.cend(); c++) {
+            switch (*c) {
+            case '"': o << "\\\""; break;
+            case '\\': o << "\\\\"; break;
+            case '\b': o << "\\b"; break;
+            case '\f': o << "\\f"; break;
+            case '\n': o << "\\n"; break;
+            case '\r': o << "\\r"; break;
+            case '\t': o << "\\t"; break;
+            default:
+                if ('\x00' <= *c && *c <= '\x1f') {
+                    o << "\\u"
+                      << std::hex << std::setw(4) << std::setfill('0') << (int)*c;
+                } else {
+                    o << *c;
+                }
+            }
+        }
+        return o.str();
+    }
+    
     // Serialize the HidDeviceInformation in a JSON format
     std::wostream& operator<<(_Inout_ std::wostream& os, _In_ HidHide::HidDeviceInformation const& hidDeviceInformation)
     {
         os  << L"{ " \
             << L"\"present\" : " << std::boolalpha << hidDeviceInformation.present << L" ," << std::endl \
             << L"\"gamingDevice\" : " << std::boolalpha << hidDeviceInformation.gamingDevice << L" ," << std::endl \
-            << L"\"symbolicLink\" : \"" << hidDeviceInformation.symbolicLink.wstring() << L"\" ," << std::endl \
-            << L"\"vendor\" : \"" << hidDeviceInformation.vendor << L"\" ," << std::endl \
-            << L"\"product\" : \"" << hidDeviceInformation.product << L"\" ," << std::endl \
-            << L"\"serialNumber\" : \"" << hidDeviceInformation.serialNumber << L"\" ," << std::endl \
-            << L"\"usage\" : \"" << hidDeviceInformation.usage << L"\" ," << std::endl \
-            << L"\"description\" : \"" << hidDeviceInformation.description << L"\" ," << std::endl \
-            << L"\"deviceInstancePath\" : \"" << hidDeviceInformation.deviceInstancePath << L"\" ," << std::endl \
-            << L"\"baseContainerDeviceInstancePath\" : \"" << hidDeviceInformation.baseContainerDeviceInstancePath << L"\" ," << std::endl \
-            << L"\"baseContainerClassGuid\" : \"" << HidHide::GuidToString(hidDeviceInformation.baseContainerClassGuid) << L"\" ," << std::endl \
+            << L"\"symbolicLink\" : \"" << escape_json(hidDeviceInformation.symbolicLink.wstring()) << L"\" ," << std::endl \
+            << L"\"vendor\" : \"" << escape_json(hidDeviceInformation.vendor) << L"\" ," << std::endl \
+            << L"\"product\" : \"" << escape_json(hidDeviceInformation.product) << L"\" ," << std::endl \
+            << L"\"serialNumber\" : \"" << escape_json(hidDeviceInformation.serialNumber) << L"\" ," << std::endl \
+            << L"\"usage\" : \"" << escape_json(hidDeviceInformation.usage) << L"\" ," << std::endl \
+            << L"\"description\" : \"" << escape_json(hidDeviceInformation.description) << L"\" ," << std::endl \
+            << L"\"deviceInstancePath\" : \"" << escape_json(hidDeviceInformation.deviceInstancePath) << L"\" ," << std::endl \
+            << L"\"baseContainerDeviceInstancePath\" : \"" << escape_json(hidDeviceInformation.baseContainerDeviceInstancePath) << L"\" ," << std::endl \
+            << L"\"baseContainerClassGuid\" : \"" << escape_json(HidHide::GuidToString(hidDeviceInformation.baseContainerClassGuid)) << L"\" ," << std::endl \
             << L"\"baseContainerDeviceCount\" : " << hidDeviceInformation.baseContainerDeviceCount << L" }";
         return (os);
     }
@@ -51,7 +77,7 @@ namespace
         for (auto const& hidContainer : hidDevices)
         {
             if (first) first = false; else os << L"," << std::endl;
-            os << L"{ \"friendlyName\" : \"" << hidContainer.first << L"\" , \"devices\" :" << hidContainer.second << L"} ";
+            os << L"{ \"friendlyName\" : \"" << escape_json(hidContainer.first) << L"\" , \"devices\" :" << hidContainer.second << L"} ";
         }
         os << L"] " << std::endl;
         return (os);

--- a/HidHideCLI/src/Commands.cpp
+++ b/HidHideCLI/src/Commands.cpp
@@ -13,23 +13,24 @@
 namespace
 {
     // https://stackoverflow.com/a/33799784
-    std::string escape_json(const std::string &s) {
-        std::ostringstream o;
-        for (auto c = s.cbegin(); c != s.cend(); c++) {
-            switch (*c) {
-            case '"': o << "\\\""; break;
-            case '\\': o << "\\\\"; break;
-            case '\b': o << "\\b"; break;
-            case '\f': o << "\\f"; break;
-            case '\n': o << "\\n"; break;
-            case '\r': o << "\\r"; break;
-            case '\t': o << "\\t"; break;
+    std::wstring escape_json(const std::wstring &s) {
+        std::wostringstream o;
+        for (const wchar_t c : s)
+        {
+            switch (c) {
+            case L'"': o << L"\\\""; break;
+            case L'\\': o << L"\\\\"; break;
+            case L'\b': o << L"\\b"; break;
+            case L'\f': o << L"\\f"; break;
+            case L'\n': o << L"\\n"; break;
+            case L'\r': o << L"\\r"; break;
+            case L'\t': o << L"\\t"; break;
             default:
-                if ('\x00' <= *c && *c <= '\x1f') {
+                if (L'\x00' <= c && c <= L'\x1f') {
                     o << "\\u"
-                      << std::hex << std::setw(4) << std::setfill('0') << (int)*c;
+                      << std::hex << std::setw(4) << std::setfill(L'0') << static_cast<int>(c);
                 } else {
-                    o << *c;
+                    o << c;
                 }
             }
         }

--- a/HidHideCLI/src/Commands.cpp
+++ b/HidHideCLI/src/Commands.cpp
@@ -256,7 +256,7 @@ namespace HidHide
     void CommandInterpreter::DevAll(Args const&) const
     {
         TRACE_ALWAYS(L"");
-        std::wcout << HidHide::HidDevices(true) << std::endl;
+        std::wcout << HidHide::HidDevices(false) << std::endl;
     }
 
     _Use_decl_annotations_


### PR DESCRIPTION
Noticed that the JSON format of the CLI is invalid when listing devices.

Here is sample JSON output as of current version 1.1.50 from the CLI command "--dev-gaming":

```json
 [ { "friendlyName" : Controller (Xbox One For Windows)" , "devices" : [
{ "present" : true ,
"gamingDevice" : true ,
"symbolicLink" : "\\?\hid#vid_045e&pid_0b00&ig_00#7&2f3ffc5e&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}" ,
"vendor" : "" ,
"product" : "Controller (Xbox One For Windows)" ,
"serialNumber" : "" ,
"usage" : "Gamepad" ,
"description" : "Xbox One Wireless Controller" ,
"deviceInstancePath" : "HID\VID_045E&PID_0B00&IG_00\7&2f3ffc5e&0&0000" ,
"baseContainerDeviceInstancePath" : "USB\VID_045E&PID_0B00&IG_00\00&00&0000728AB982ED7E" ,
"baseContainerClassGuid" : "{745A17A0-74D3-11D0-B6FE-00A0C90F57DA}" ,
"baseContainerDeviceCount" : 1 } ] } ]
```

Note the JSON syntax errors highlighted in this code block. In particular, the `friendlyName` value only has an end quote but is missing its beginning, and none of the JSON strings are escaped, which is particularly problematic for `symbolicLink`, `deviceInstancePath` and `baseContainerDeviceInstancePath` as all of these values are expected to contain backslashes, which must be escaped. Compounded, these issues render the output from `--dev-gaming` or `--dev-all` impossible to parse by any standard JSON library.

This pull request is a C++ novice's attempt to fix these JSON formatting errors by simply inserting the beginning quote for `friendlyName` and adding a simple `escape_json` method that I got off stackoverflow for use when outputting string data.

Needs testing, please feel free to make modifications as needed.