### PR TITLE
 Adds the Chocolatey package as a way to install HidHide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # HidHide
 
-[![Build status](https://ci.appveyor.com/api/projects/status/s3t4ffx5fnfw5g65/branch/master?svg=true)](https://ci.appveyor.com/project/nefarius/hidhide/branch/master) [![GitHub All Releases](https://img.shields.io/github/downloads/ViGEm/HidHide/total)](https://somsubhra.github.io/github-release-stats/?username=ViGEm&repository=HidHide) ![Lines of code](https://img.shields.io/tokei/lines/github/ViGEm/HidHide) ![GitHub issues by-label](https://img.shields.io/github/issues/ViGEm/HidHide/bug) ![GitHub issues by-label](https://img.shields.io/github/issues/ViGEm/HidHide/enhancement)
+[![Build status](https://ci.appveyor.com/api/projects/status/s3t4ffx5fnfw5g65/branch/master?svg=true)](https://ci.appveyor.com/project/nefarius/hidhide/branch/master)
+[![GitHub All Releases](https://img.shields.io/github/downloads/ViGEm/HidHide/total)](https://somsubhra.github.io/github-release-stats/?username=ViGEm&repository=HidHide)
+[![Chocolatey package](https://img.shields.io/chocolatey/dt/hidhide?color=blue&label=chocolatey)](https://community.chocolatey.org/packages/hidhide)
+![Lines of code](https://img.shields.io/tokei/lines/github/ViGEm/HidHide)
+![GitHub issues by-label](https://img.shields.io/github/issues/ViGEm/HidHide/bug)
+![GitHub issues by-label](https://img.shields.io/github/issues/ViGEm/HidHide/enhancement)
 
 ## Introduction
 


### PR DESCRIPTION
Hi @HidHide_devs,

I have created this Pull Request because I have resolved this [request for a Chocolatey package](https://github.com/chocolatey-community/chocolatey-package-requests/issues/1352) and now, we can install **hidhide** using [Chocolatey](https://community.chocolatey.org/packages/hidhide).

For now, only the latest version (`1.2.98.0`) is available on Chocolatey. When new versions will be released, they will, then, be added to the Chocolatey package for users to enjoy. :slightly_smiling_face: 

